### PR TITLE
fix: Export type and add option to ignore t errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.3",
   "private": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/hooks/__test__/useTranslation.test.tsx
+++ b/src/hooks/__test__/useTranslation.test.tsx
@@ -56,3 +56,9 @@ it('returns an error message if the key does not exist', () => {
 
   consoleError.mockRestore()
 })
+
+it('returns an empty string if the key dos not exist and ignoreError is true', () => {
+  const { result } = renderHook(() => useTranslation(), { wrapper: MockTranslationContext })
+
+  expect(result.current.t('bye', {}, { ignoreError: true })).toBe('')
+})

--- a/src/hooks/useTranslation.ts
+++ b/src/hooks/useTranslation.ts
@@ -4,7 +4,9 @@ import accessDeepProperty from 'lodash.get'
 import { interpolate, Interpolations } from '../utils'
 import useTranslationContext from './useTranslationContext'
 
-type Translate = (key: string, interpolations?: Interpolations) => string
+type Options = { ignoreError?: boolean }
+
+type Translate = (key: string, interpolations?: Interpolations, options?: Options) => string
 
 export const useTranslation = () => {
   const { language, locale } = useTranslationContext()
@@ -15,10 +17,12 @@ export const useTranslation = () => {
     return errorMessage
   }, [language])
 
-  const t = useCallback<Translate>((key, interpolations) => {
+  const t = useCallback<Translate>((key, interpolations, options = {}) => {
     const rawTranslation = accessDeepProperty(locale, key)
 
     if (typeof rawTranslation !== 'string') {
+      if (options.ignoreError) return ''
+
       return handleTranslationError(key)
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { TranslationContainer } from './components'
 export { useTranslation } from './hooks'
+export { type Locales, type Locale } from './types'


### PR DESCRIPTION
- Adds `src` to the npm package (this way our sourcemaps work)
- Exports the Locales and Locale types
- Adds an option to ignore translation errors (required by wa-interaction)