### PR TITLE
Add local Storage Language

### DIFF
--- a/src/__test__/integration.test.tsx
+++ b/src/__test__/integration.test.tsx
@@ -58,7 +58,10 @@ const renderContainer = (props?: Props, translationProps?: TranslationProps) => 
   )
 }
 
-beforeEach(() => { setBrowserLanguage('pt-BR') })
+beforeEach(() => {
+  setBrowserLanguage('pt-BR')
+  localStorage.removeItem('lang')
+})
 
 it('translates the given key', () => {
   renderContainer()

--- a/src/components/__test__/index.test.tsx
+++ b/src/components/__test__/index.test.tsx
@@ -57,7 +57,10 @@ const ContextTester = () => {
   return <button onClick={updateLanguage}>setLanguage</button>
 }
 
-beforeEach(() => { setBrowserLanguage('pt-BR') })
+beforeEach(() => {
+  setBrowserLanguage('pt-BR')
+  localStorage.removeItem('lang')
+})
 
 it('updates the locale on setLanguage called', () => {
   renderContainer({ children: <ContextTester /> })
@@ -82,6 +85,19 @@ it('updates the locale on setLanguage called', () => {
 
 it('gets the initial locale from the browser language', () => {
   setBrowserLanguage('en-US')
+
+  renderContainer({ children: <ContextTester /> })
+
+  expect(contextValueTester).toHaveBeenLastCalledWith({
+    language: 'en-US',
+    setLanguage: expect.any(Function),
+    locales: locales,
+    locale: locales['en-US']
+  })
+})
+
+it('gets the initial locale from the local Storage language', () => {
+  localStorage.setItem('lang', 'en-US')
 
   renderContainer({ children: <ContextTester /> })
 

--- a/src/hooks/__test__/useLanguage.test.ts
+++ b/src/hooks/__test__/useLanguage.test.ts
@@ -3,10 +3,24 @@ import { act, renderHook, waitFor } from '@testing-library/react'
 import { setBrowserLanguage } from '../../utils'
 import { useLanguage } from '..'
 
-beforeEach(() => { setBrowserLanguage('pt-BR') })
+beforeEach(() => {
+  setBrowserLanguage('pt-BR')
+  localStorage.removeItem('lang')
+})
 
 it('gets the initial locale from the browser language', () => {
   setBrowserLanguage('en-US')
+
+  const { result } = renderHook(() => useLanguage(['en-US', 'pt-BR'], 'pt-BR'))
+
+  const [language] = result.current
+
+  expect(language).toEqual('en-US')
+})
+
+it('gets the initial locale from the Local Storage language', () => {
+  localStorage.setItem('lang', 'en-US')
+  setBrowserLanguage('pt-BR')
 
   const { result } = renderHook(() => useLanguage(['en-US', 'pt-BR'], 'pt-BR'))
 

--- a/src/hooks/useLanguage.ts
+++ b/src/hooks/useLanguage.ts
@@ -39,6 +39,7 @@ const useLanguage: UseLanguage = (supportedLanguages: string[], defaultLanguage:
     const isLanguageSupported = supportedLanguages.includes(language)
     const newLanguage = isLanguageSupported ? language : defaultLanguage
     setLanguage(newLanguage)
+    localStorage.setItem('lang', newLanguage)
 
     if (!isLanguageSupported) {
       console.error('Unsupported language: ', language)

--- a/src/hooks/useLanguage.ts
+++ b/src/hooks/useLanguage.ts
@@ -5,9 +5,29 @@ type UseLanguage = (supportedLanguages: string[], defaultLanguage: string) => (
 )
 
 const useLanguage: UseLanguage = (supportedLanguages: string[], defaultLanguage: string) => {
-  const browserLanguage = window.navigator.language
-  const isBrowserLangSupported = supportedLanguages.includes(browserLanguage)
-  const initialLanguage = isBrowserLangSupported ? browserLanguage : defaultLanguage
+  const getLocalLanguage = () => {
+    const localLang = localStorage.getItem('lang')
+    if (typeof localLang === 'string') {
+      const isLocalLangSupported = supportedLanguages.includes(localLang)
+
+      return isLocalLangSupported ? localLang : ''
+    }
+    return ''
+  }
+
+  const localLanguage = getLocalLanguage()
+
+  let initialLanguage:string
+
+  if (localLanguage !== '') {
+    initialLanguage = localLanguage
+  } else {
+    const browserLanguage = window.navigator.language
+    const isBrowserLangSupported = supportedLanguages.includes(browserLanguage)
+    initialLanguage = isBrowserLangSupported ? browserLanguage : defaultLanguage
+  }
+
+  localStorage.setItem('lang', initialLanguage)
 
   const [language, setLanguage] = useState(initialLanguage)
 


### PR DESCRIPTION
A alteração foi realizada para a primeira prioridade para escolha da linguagem no I18N ser a que estiver salva no localStorage dentro da variável lang, segunda prioridade ser o default do Browser e a terceira a defaultLanguage da props.
Quando ele não tiver a variável no localStorage ele irá pegar a linguagem da próxima prioridade e adicionar ao localStorage.lang.
Quando for alterado a linguagem pelo SetLanguage, se a linguagem for suportada  ira adicionar ao localStorage.lang a linguagem nova, caso não seja suportada será feito o mesmo processo porem com  a defaultLanguage passada via props.